### PR TITLE
Bound command health check pipe waits

### DIFF
--- a/runner/BUILD.bazel
+++ b/runner/BUILD.bazel
@@ -20,7 +20,10 @@ go_library(
 
 go_test(
     name = "runner_test",
-    srcs = ["runner_test.go"],
+    srcs = [
+        "runner_test.go",
+        "service_instance_test.go",
+    ],
     embed = [":runner"],
     deps = ["//svclib"],
 )

--- a/runner/service_instance.go
+++ b/runner/service_instance.go
@@ -165,6 +165,9 @@ func (s *ServiceInstance) HealthCheck(ctx context.Context, expectedStartDuration
 		}
 
 		cmd := exec.CommandContext(ctx, s.ServiceSpec.HealthCheck, s.HealthCheckArgs...)
+		// A descendant may inherit the health check's output pipes. Bound the
+		// post-exit wait so one attempt cannot block service startup indefinitely.
+		cmd.WaitDelay = 50 * time.Millisecond
 		if shouldSilence {
 			cmd.Stdout = io.Discard
 			cmd.Stderr = io.Discard
@@ -173,6 +176,9 @@ func (s *ServiceInstance) HealthCheck(ctx context.Context, expectedStartDuration
 			cmd.Stderr = logger.New(s.Label+"? ", s.Color, os.Stderr)
 		}
 		err = cmd.Run()
+		if errors.Is(err, exec.ErrWaitDelay) && ctx.Err() == nil && cmd.ProcessState != nil && cmd.ProcessState.Success() {
+			err = nil
+		}
 		if err != nil {
 			cmd.Stdout.Write([]byte(err.Error()))
 			isHealthy = false

--- a/runner/service_instance_test.go
+++ b/runner/service_instance_test.go
@@ -1,0 +1,59 @@
+package runner
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"testing"
+	"time"
+
+	"rules_itest/svclib"
+)
+
+func TestCommandHealthCheckBoundsInheritedOutputPipeWait(t *testing.T) {
+	t.Setenv("RULES_ITEST_HEALTHCHECK_HELPER", "1")
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	service := &ServiceInstance{
+		VersionedServiceSpec: svclib.VersionedServiceSpec{ServiceSpec: svclib.ServiceSpec{
+			Type:            "service",
+			Label:           "//example:service",
+			HealthCheck:     executable,
+			HealthCheckArgs: []string{"-test.run=TestCommandHealthCheckHelperProcess"},
+		}},
+		cmd: &exec.Cmd{Process: &os.Process{Pid: os.Getpid()}},
+	}
+
+	start := time.Now()
+	if !service.HealthCheck(context.Background(), 0) {
+		t.Fatal("HealthCheck() = false, want successful health-check exit to remain successful")
+	}
+	if elapsed := time.Since(start); elapsed >= time.Second {
+		t.Fatalf("HealthCheck() took %s, want less than 1s", elapsed)
+	}
+}
+
+func TestCommandHealthCheckHelperProcess(t *testing.T) {
+	if os.Getenv("RULES_ITEST_HEALTHCHECK_HELPER") != "1" {
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestCommandHealthCheckDescendantProcess")
+	cmd.Env = append(os.Environ(), "RULES_ITEST_HEALTHCHECK_DESCENDANT=1")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		os.Exit(2)
+	}
+	os.Exit(0)
+}
+
+func TestCommandHealthCheckDescendantProcess(t *testing.T) {
+	if os.Getenv("RULES_ITEST_HEALTHCHECK_DESCENDANT") != "1" {
+		return
+	}
+	time.Sleep(2 * time.Second)
+}


### PR DESCRIPTION
Fixes #92.

- Bound the post-exit wait for command health-check output pipes.
- Preserve a successful health-check exit when only inherited pipes time out.
- Add a helper-process regression test.